### PR TITLE
adding unzip to the ADO images

### DIFF
--- a/managed-containers/ado-az-pwsh-runner/Dockerfile
+++ b/managed-containers/ado-az-pwsh-runner/Dockerfile
@@ -9,7 +9,17 @@ ENV DEBIAN_FRONTEND=noninteractive
 COPY base_packages.list /tmp/base_packages.list
 COPY addon_packages.list /tmp/addon_packages.list
 
-# Install baseline
+# Install ca-certificates
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/* 
+
+# apt-get shapshot id
+ARG SNAPSHOT_ID=20250530T181600Z
+RUN echo "APT::Snapshot \"${SNAPSHOT_ID}\";" \
+     > /etc/apt/apt.conf.d/50snapshot
+
+# Install snapshotted baseline packages
 RUN apt-get update && \
     xargs -a /tmp/base_packages.list apt-get install -y --no-install-recommends && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -20,7 +30,7 @@ RUN curl -sSL https://packages.microsoft.com/keys/microsoft.asc -o /tmp/microsof
     echo "deb [signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/ubuntu/$(lsb_release -rs)/prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/microsoft-prod.list && \
     echo "deb [signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list
   
-# Install addons
+# Install snapshotted addon packages
 RUN apt-get update && \
     xargs -a /tmp/addon_packages.list apt-get install -y --no-install-recommends && \
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/managed-containers/ado-az-pwsh-runner/Dockerfile
+++ b/managed-containers/ado-az-pwsh-runner/Dockerfile
@@ -10,6 +10,7 @@ COPY base_packages.list /tmp/base_packages.list
 COPY addon_packages.list /tmp/addon_packages.list
 
 # Install ca-certificates
+# hadolint ignore=DL3008
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates \
  && rm -rf /var/lib/apt/lists/* 

--- a/managed-containers/ado-az-pwsh-runner/base_packages.list
+++ b/managed-containers/ado-az-pwsh-runner/base_packages.list
@@ -9,3 +9,4 @@ debsums:all=3.0.2.1
 liblttng-ust1t64:amd64=2.13.7-1.1ubuntu2
 libicu74:amd64=74.2-1ubuntu3.1
 wget:amd64=1.21.4-1ubuntu4.1
+unzip:amd64=6.0-28ubuntu4.1

--- a/managed-containers/ado-az-tf-pwsh-runner/Dockerfile
+++ b/managed-containers/ado-az-tf-pwsh-runner/Dockerfile
@@ -9,7 +9,17 @@ ENV DEBIAN_FRONTEND=noninteractive
 COPY base_packages.list /tmp/base_packages.list
 COPY addon_packages.list /tmp/addon_packages.list
 
-# Install baseline
+# Install ca-certificates
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/* 
+
+# apt-get shapshot id
+ARG SNAPSHOT_ID=20250530T181600Z
+RUN echo "APT::Snapshot \"${SNAPSHOT_ID}\";" \
+     > /etc/apt/apt.conf.d/50snapshot
+
+# Install snapshotted baseline packages
 RUN apt-get update && \
     xargs -a /tmp/base_packages.list apt-get install -y --no-install-recommends && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -23,7 +33,7 @@ RUN curl -fsSL https://apt.releases.hashicorp.com/gpg -o /tmp/hashicorp.gpg && \
     echo "deb [signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/ubuntu/$(lsb_release -rs)/prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/microsoft-prod.list && \
     echo "deb [signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list
   
-# Install addons
+# Install snapshotted addon packages
 RUN apt-get update && \
     xargs -a /tmp/addon_packages.list apt-get install -y --no-install-recommends && \
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/managed-containers/ado-az-tf-pwsh-runner/Dockerfile
+++ b/managed-containers/ado-az-tf-pwsh-runner/Dockerfile
@@ -10,6 +10,7 @@ COPY base_packages.list /tmp/base_packages.list
 COPY addon_packages.list /tmp/addon_packages.list
 
 # Install ca-certificates
+# hadolint ignore=DL3008
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates \
  && rm -rf /var/lib/apt/lists/* 

--- a/managed-containers/ado-az-tf-pwsh-runner/base_packages.list
+++ b/managed-containers/ado-az-tf-pwsh-runner/base_packages.list
@@ -9,3 +9,4 @@ debsums:all=3.0.2.1
 liblttng-ust1t64:amd64=2.13.7-1.1ubuntu2
 libicu74:amd64=74.2-1ubuntu3.1
 wget:amd64=1.21.4-1ubuntu4.1
+unzip:amd64=6.0-28ubuntu4.1


### PR DESCRIPTION
Was speaking with @simon-wang-gc  about how the runner images need unzip. 

This PR add's unzip to the PR but it also introduces the idea of ubuntu package snapshotting. 

https://snapshot.ubuntu.com/

now its possible to properly pin packages and libraries in ubuntu.