### PR TITLE
Disables dependency checking in PyLint

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -8,7 +8,8 @@ disable =
     C0115,  # missing-class-docstring
     C0116,  # missing-function-docstring
     R0903,  # too-few-public-methods
-    R0801   # duplicate-code
+    R0801,  # duplicate-code
+    E0401   # import-error (handled by mypy)
 
 [FORMAT]
 max-line-length = 120


### PR DESCRIPTION
we have redundant dependency checking and its not handled properly by PyLint in the mono repo configuration. 

This changes disables dependency checking in Pylint. MyPy will instead do the validation.