### PR TITLE
Meta linkages

### DIFF
--- a/.github/workflows/publish-dockerfile.yml
+++ b/.github/workflows/publish-dockerfile.yml
@@ -142,7 +142,6 @@ jobs:
               --label "org.opencontainers.image.ref.name=${REF_NAME}" \
               --label "org.opencontainers.image.source=${SOURCE_URL}" \
               -t "$repo_path" \
-              -t "$tag_sha" \
               -f "$dockerfile" "$dockerfile_path"
 
             # Push the Docker image to the GitHub Container Registry

--- a/.github/workflows/publish-dockerfile.yml
+++ b/.github/workflows/publish-dockerfile.yml
@@ -111,6 +111,11 @@ jobs:
 
           echo "Dockerfile files to process: ${dockerfiles_list[*]}"
 
+          REVISION="${GITHUB_SHA}"
+          CREATED="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          REF_NAME="${{ github.ref_name }}"
+          SOURCE_URL="https://github.com/${{ github.repository }}"
+
           # Iterate through each Dockerfile path
           for dockerfile in "${dockerfiles_list[@]}"; do
             # Extract the directory containing the Dockerfile
@@ -130,7 +135,15 @@ jobs:
             echo "Building Docker image: $image_name from $dockerfile"
 
             # Build the Docker image using Docker Buildx with --no-cache to ensure fresh layers
-            docker buildx build --load --no-cache -t "$repo_path" -f "$dockerfile" "$dockerfile_path"
+            docker buildx build --load --no-cache \
+              --platform=linux/amd64 \
+              --label "org.opencontainers.image.revision=${REVISION}" \
+              --label "org.opencontainers.image.created=${CREATED}" \
+              --label "org.opencontainers.image.ref.name=${REF_NAME}" \
+              --label "org.opencontainers.image.source=${SOURCE_URL}" \
+              -t "$repo_path" \
+              -t "$tag_sha" \
+              -f "$dockerfile" "$dockerfile_path"
 
             # Push the Docker image to the GitHub Container Registry
             docker push "$repo_path"


### PR DESCRIPTION
Will add build meta information to dockerfile manifests at build time. This will provide backward tracability to show what code was used to build which containers when and by who 

The manifest should look similar to 

```json
{
  "labels": {
    "org.opencontainers.image.description": "Container Job to rotate Storage Account SAS tokens",
    "org.opencontainers.image.source": "https://github.com/fsdh-pfds/datahub-images",
    "org.opencontainers.image.url": "https://github.com/fsdh-pfds/datahub-images/blob/main/managed-containers/proj-sas-worker/README.md",
    "org.opencontainers.image.ref.name": "main",
    "org.opencontainers.image.version": "24.04",
    "org.opencontainers.image.revision": "c3997435e4057b802dc64f6377697389713771ae",
    "org.opencontainers.image.created": "2025-09-15T15:23:47Z"
  },
  "digest": "sha256:exampledigest1234567890abcdef...",
  "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
  "size": 2850,
  "config": {
    "digest": "sha256:configdigest1234567890abcdef...",
    "mediaType": "application/vnd.docker.container.image.v1+json",
    "size": 7400
  },
  "layers": [
    {
      "digest": "sha256:layer1...",
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "size": 30586847
    },
    {
      "digest": "sha256:layer2...",
      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
      "size": 240595218
    }
  ]
}

```
