### PR TITLE
Remove platform logic from Dockerfile

### DIFF
--- a/managed-containers/clamav-blobavscan/Dockerfile
+++ b/managed-containers/clamav-blobavscan/Dockerfile
@@ -6,11 +6,6 @@ LABEL org.opencontainers.image.description="ClamAV image used to antivirus scan 
 LABEL org.opencontainers.image.source="https://github.com/fsdh-pfds/datahub-images"
 LABEL org.opencontainers.image.url="https://github.com/fsdh-pfds/datahub-images/blob/main/managed-containers/clamav-blobavscan/README.md"
 
-# Target platform check docker buildx build --platform linux/amd64
-ARG TARGETPLATFORM
-RUN test "${TARGETPLATFORM:-linux/amd64}" = "linux/amd64" || \
-    (echo "ERROR: This image must be built for linux/amd64 (got: ${TARGETPLATFORM:-unset})" >&2; exit 1)
-
 ENV DataHub_ENVNAME=dev \
     AzureTenantId= \
     AzureSubscriptionId= \

--- a/managed-containers/clamav-blobavscan/Dockerfile
+++ b/managed-containers/clamav-blobavscan/Dockerfile
@@ -1,4 +1,3 @@
-# Pinned to the amd64 build of ubuntu:24.04 for reproducibility and to avoid multi-arch resolution.
 # Update digest via: docker buildx imagetools inspect ubuntu:24.04 | grep amd64
 FROM ubuntu:24.04@sha256:dc17125eaac86538c57da886e494a34489122fb6a3ebb6411153d742594c2ddc
 


### PR DESCRIPTION
The base image is pinned to an amd64 container this is redundant.