### PR TITLE
update with jfrog config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
   "name": "Ubuntu",
   "image": "mcr.microsoft.com/devcontainers/base:jammy",
   "features": {
+    "ghcr.io/devcontainers-extra/features/jfrog-cli-npm:1": {},
     "ghcr.io/devcontainers/features/go:1": {
       "version": "latest"
     },

--- a/.github/workflows/pr-build-scan.yml
+++ b/.github/workflows/pr-build-scan.yml
@@ -86,6 +86,21 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
         # Set up Docker Buildx, which allows building multi-platform Docker images
 
+      - name: Setup JFrog CLI (OIDC)
+        id: setup-jfrog-cli
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
+        with:
+          oidc-provider-name: github-oidc
+
+      - name: Secure GC Artifacts login
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
+          username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
+          password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
+
       - name: Build and Scan Docker Images
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-build-scan.yml
+++ b/.github/workflows/pr-build-scan.yml
@@ -13,6 +13,8 @@ permissions: read-all
 jobs:
   build-and-scan:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4

--- a/.github/workflows/publish-dockerfile.yml
+++ b/.github/workflows/publish-dockerfile.yml
@@ -17,6 +17,7 @@ jobs:
       contents: write
       packages: write
       security-events: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4

--- a/.github/workflows/publish-dockerfile.yml
+++ b/.github/workflows/publish-dockerfile.yml
@@ -90,6 +90,21 @@ jobs:
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3
         # Set up Docker Buildx, which allows building multi-platform Docker images
 
+      - name: Setup JFrog CLI (OIDC)
+        id: setup-jfrog-cli
+        uses: jfrog/setup-jfrog-cli@v4
+        env:
+          JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
+        with:
+          oidc-provider-name: github-oidc
+
+      - name: Secure GC Artifacts login
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
+        with:
+          registry: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
+          username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
+          password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
+
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
         with:

--- a/managed-containers/datahub-portal-dev/Dockerfile
+++ b/managed-containers/datahub-portal-dev/Dockerfile
@@ -1,1 +1,0 @@
-FROM ghcr.io/ssc-sp/datahub-portal/datahub-portal:dev-latest

--- a/managed-containers/datahub-portal-dev/Dockerfile
+++ b/managed-containers/datahub-portal-dev/Dockerfile
@@ -1,0 +1,1 @@
+FROM ghcr.io/ssc-sp/datahub-portal/datahub-portal:dev-latest

--- a/managed-containers/gc-secure-artifacts-test/Dockerfile
+++ b/managed-containers/gc-secure-artifacts-test/Dockerfile
@@ -1,2 +1,2 @@
-#FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python@sha256:67f2a11126fc38c9c9a9aed1f7fa9ed24e4ac45b3e019be1c2f10f9f419e8550
-FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python:latest
+FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python@sha256:67f2a11126fc38c9c9a9aed1f7fa9ed24e4ac45b3e019be1c2f10f9f419e8550
+#FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python:latest

--- a/managed-containers/gc-secure-artifacts-test/Dockerfile
+++ b/managed-containers/gc-secure-artifacts-test/Dockerfile
@@ -1,1 +1,1 @@
-FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python:latest
+FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python@sha256:67f2a11126fc38c9c9a9aed1f7fa9ed24e4ac45b3e019be1c2f10f9f419e8550

--- a/managed-containers/gc-secure-artifacts-test/Dockerfile
+++ b/managed-containers/gc-secure-artifacts-test/Dockerfile
@@ -1,2 +1,1 @@
 FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python:latest@sha256:4110988c0fca39ff45ac82120e72c5043a952dff1746bd2a858417d8737f839f
-#FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python:latest

--- a/managed-containers/gc-secure-artifacts-test/Dockerfile
+++ b/managed-containers/gc-secure-artifacts-test/Dockerfile
@@ -1,1 +1,2 @@
-FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python@sha256:67f2a11126fc38c9c9a9aed1f7fa9ed24e4ac45b3e019be1c2f10f9f419e8550
+#FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python@sha256:67f2a11126fc38c9c9a9aed1f7fa9ed24e4ac45b3e019be1c2f10f9f419e8550
+FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python:latest

--- a/managed-containers/gc-secure-artifacts-test/Dockerfile
+++ b/managed-containers/gc-secure-artifacts-test/Dockerfile
@@ -1,0 +1,1 @@
+FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python:latest

--- a/managed-containers/gc-secure-artifacts-test/Dockerfile
+++ b/managed-containers/gc-secure-artifacts-test/Dockerfile
@@ -1,2 +1,2 @@
-FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python@sha256:67f2a11126fc38c9c9a9aed1f7fa9ed24e4ac45b3e019be1c2f10f9f419e8550
+FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python:latest@sha256:4110988c0fca39ff45ac82120e72c5043a952dff1746bd2a858417d8737f839f
 #FROM artifacts-artefacts.devops.cloud-nuage.canada.ca/docker-chainguard-remote/ssc-spc.gc.ca/python:latest

--- a/managed-containers/gc-secure-artifacts-test/README.md
+++ b/managed-containers/gc-secure-artifacts-test/README.md
@@ -1,0 +1,12 @@
+# gc-secure-artifacts-test
+
+A minimal and typical container image used to validate pulling from the **GC Secure Artifacts** JFrog instance. This image is managed and updated by Chainguard and is wired into GC Security Artifacts chainguard proxy.
+
+> **Status**: Experimental. Intended for pipeline validation and end‑to‑end artifact flow testing.
+
+---
+
+## What this image is for
+
+- Prove out **OIDC-based auth** from GitHub Actions to JFrog Artifactory (no long‑lived secrets).
+- Provide a tiny runnable image for smoke tests (e.g., `docker pull` responds and exits cleanly).


### PR DESCRIPTION
update pipelines to support gc secure artifacts 

Managed OIDC Identity for pulling in Jfrog 
<img width="611" height="752" alt="image" src="https://github.com/user-attachments/assets/d2609ac0-7798-4fac-ac37-d7e5950a87b5" />

update to pipes
```
      - name: Setup JFrog CLI (OIDC)
        id: setup-jfrog-cli
        uses: jfrog/setup-jfrog-cli@v4
        env:
          JF_URL: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
        with:
          oidc-provider-name: github-oidc

      - name: Secure GC Artifacts login
        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3
        with:
          registry: https://artifacts-artefacts.devops.cloud-nuage.canada.ca
          username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
          password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
```

